### PR TITLE
feat: update user message bubble background color to #303030

### DIFF
--- a/app/components/chat/MessageBubble.tsx
+++ b/app/components/chat/MessageBubble.tsx
@@ -28,10 +28,10 @@ export default function MessageBubble({ message }: MessageBubbleProps) {
                 <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'}`}>
                     <div
                         className={`${isUser
-                                ? 'px-4 py-3 rounded-3xl bg-gray-600 text-white'
+                                ? 'px-4 py-3 rounded-3xl text-white'
                                 : 'text-white'
                             }`}
-                        style={!isUser ? { backgroundColor: 'transparent' } : {}}
+                        style={isUser ? { backgroundColor: '#303030' } : { backgroundColor: 'transparent' }}
                     >
                         <div className="text-base leading-relaxed whitespace-pre-wrap">
                             {formatContent(message.content)}


### PR DESCRIPTION
Replaced Tailwind bg-gray-600 class with inline style using the requested color #303030 to improve visual consistency and enhance chat interface appearance.

Fixes #5