### PR TITLE
feat(chat): Chain of Thought live + final, UI parity, and fixes

### DIFF
--- a/app/components/chat/ChatInterface.tsx
+++ b/app/components/chat/ChatInterface.tsx
@@ -3,7 +3,14 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { ChatMessage } from '../../lib/types';
 import MessageBubble from './MessageBubble';
-import ProcessSteps, { ProcessStep } from './ProcessSteps';
+import type { ProcessStep } from './ProcessSteps';
+import {
+  ChainOfThought,
+  ChainOfThoughtContent,
+  ChainOfThoughtHeader,
+  ChainOfThoughtStep,
+} from '@/components/ai-elements/chain-of-thought';
+import { Search, Building2, FileSearch, ListChecks, FileText, LineChart, MessageSquare, BarChart3 } from 'lucide-react';
 import { ArrowUpIcon } from '@heroicons/react/24/outline';
 import { BorderBeam } from '../ui/magicui/border-beam';
 import { Button } from '../ui/Button';
@@ -15,8 +22,11 @@ interface ChatInterfaceProps {
   onSendMessage: (message: string) => void;
   isLoading: boolean;
   currentProcessStep?: ProcessStep;
+  chainOfThoughtSteps?: ProcessStep[];
   onAddToBoard?: (chartData: any, title: string) => void;
   showAddToBoardButtons?: boolean;
+  // True when the layout is split (chat + board). Used to adjust input position.
+  isSplitView?: boolean;
 }
 
 export default function ChatInterface({
@@ -24,8 +34,10 @@ export default function ChatInterface({
   onSendMessage,
   isLoading,
   currentProcessStep,
+  chainOfThoughtSteps = [],
   onAddToBoard,
   showAddToBoardButtons,
+  isSplitView = false,
 }: ChatInterfaceProps) {
   const [inputValue, setInputValue] = useState('');
   const [isFocused, setIsFocused] = useState(false);
@@ -66,11 +78,12 @@ export default function ChatInterface({
   };
 
   const hasMessages = messages.length > 0;
+  const hasCoT = chainOfThoughtSteps && chainOfThoughtSteps.length > 0;
 
   return (
     <div className="shadow-lg h-full flex flex-col" style={{ backgroundColor: '#0f0f10' }}>
-      {/* Messages area when present */}
-      {hasMessages && (
+      {/* Messages area when present or when showing live Chain of Thought */}
+      {(hasMessages || hasCoT) && (
         <div className="flex-1 overflow-y-auto px-4 pt-4 space-y-4">
           {messages.map((message, index) => {
             const isNewMessage = index >= previousMessageCountRef.current;
@@ -85,9 +98,30 @@ export default function ChatInterface({
             );
           })}
 
-          {isLoading && currentProcessStep && (
-            <div className="w-full">
-              <ProcessSteps currentStep={currentProcessStep} />
+          {/* Live Chain of Thought during generation */}
+          {hasCoT && (
+            <div className="w-full max-w-3xl mx-auto">
+              <ChainOfThought defaultOpen>
+                <ChainOfThoughtHeader />
+                <ChainOfThoughtContent>
+                  {chainOfThoughtSteps.map((s, idx) => {
+                    const id = (s.id || '').toLowerCase();
+                    const Icon =
+                      id.includes('company') ? Building2 :
+                      id.includes('document_search') ? Search :
+                      id.includes('document_selection') ? ListChecks :
+                      id.includes('content_extraction') ? FileSearch :
+                      id.includes('data_analysis') ? LineChart :
+                      id.includes('response_generation') ? MessageSquare :
+                      id.includes('chart_creation') ? BarChart3 :
+                      id.includes('query') ? Search : FileText;
+                    const status: 'complete' | 'active' | 'pending' = s.status === 'completed' ? 'complete' : s.status === 'in_progress' ? 'active' : 'pending';
+                    return (
+                      <ChainOfThoughtStep key={s.id} icon={Icon} label={s.text} status={status} showConnector={idx < (chainOfThoughtSteps?.length ?? 0) - 1} />
+                    );
+                  })}
+                </ChainOfThoughtContent>
+              </ChainOfThought>
             </div>
           )}
 
@@ -95,14 +129,20 @@ export default function ChatInterface({
         </div>
       )}
 
-      {/* Input anchored at bottom */}
+      {/* When empty: add spacers to control vertical position.
+          - Split view: add top spacer to push input to bottom.
+          - Chat-only home: add top and bottom spacers to center input. */}
+      {/* Top spacer: always add when empty to enable centering or bottom anchoring */}
+      {!hasMessages && !hasCoT && <div className="flex-1" />}
+
+      {/* Input section */}
       <motion.div
         layout
         className={`px-4 pt-1 pb-4`}
         transition={{ type: 'spring', stiffness: 280, damping: 24 }}
         style={{ willChange: 'transform' }}
       >
-        {!hasMessages && (
+        {!hasMessages && !hasCoT && (
           <div className="text-center mb-6">
             <ShimmeringText
               text="Ask questions about your financial reports"
@@ -170,6 +210,9 @@ export default function ChatInterface({
           </div>
         </form>
       </motion.div>
+
+      {/* Bottom spacer: only add in chat-only home to center content */}
+      {!hasMessages && !isSplitView && !hasCoT && <div className="flex-1" />}
     </div>
   );
 }

--- a/app/components/chat/MessageBubble.tsx
+++ b/app/components/chat/MessageBubble.tsx
@@ -3,6 +3,13 @@
 import React, { useState, useEffect } from 'react';
 import { ChatMessage } from '../../lib/types';
 import FinancialChart from '../ui/FinancialChart';
+import {
+    ChainOfThought,
+    ChainOfThoughtContent,
+    ChainOfThoughtHeader,
+    ChainOfThoughtStep,
+} from '@/components/ai-elements/chain-of-thought';
+import { Search, Building2, FileSearch, ListChecks, FileText, LineChart, MessageSquare, BarChart3 } from 'lucide-react';
 
 interface MessageBubbleProps {
     message: ChatMessage;
@@ -64,7 +71,34 @@ export default function MessageBubble({ message, isNewMessage, onAddToBoard, sho
                         </div>
                     )}
 
-                    {/* Chart Display */}
+                    {/* Chain of Thought (reasoning steps) using ai-elements API */}
+                    {!isUser && message.metadata?.reasoningSteps && message.metadata.reasoningSteps.length > 0 && (
+                        <div className="w-full max-w-2xl">
+                            <ChainOfThought defaultOpen>
+                                <ChainOfThoughtHeader />
+                                <ChainOfThoughtContent>
+                                    {message.metadata.reasoningSteps.map((s, idx) => {
+                                        const id = (s.id || '').toLowerCase();
+                                        const Icon =
+                                            id.includes('company') ? Building2 :
+                                            id.includes('document_search') ? Search :
+                                            id.includes('document_selection') ? ListChecks :
+                                            id.includes('content_extraction') ? FileSearch :
+                                            id.includes('data_analysis') ? LineChart :
+                                            id.includes('response_generation') ? MessageSquare :
+                                            id.includes('chart_creation') ? BarChart3 :
+                                            id.includes('query') ? Search : FileText;
+                                        const status: 'complete' | 'active' | 'pending' = s.status === 'completed' ? 'complete' : s.status === 'in_progress' ? 'active' : 'pending';
+                                        return (
+                                            <ChainOfThoughtStep key={s.id} icon={Icon} label={s.text} status={status} showConnector={idx < (message.metadata?.reasoningSteps?.length ?? 0) - 1} />
+                                        );
+                                    })}
+                                </ChainOfThoughtContent>
+                            </ChainOfThought>
+                        </div>
+                    )}
+
+                    {/* Chart Display (below Chain of Thought) */}
                     {!isUser && message.metadata?.chartData && (
                         <div className="w-full max-w-2xl mt-3">
                             <FinancialChart 

--- a/app/components/layout/SplitViewLayout.tsx
+++ b/app/components/layout/SplitViewLayout.tsx
@@ -17,6 +17,7 @@ interface SplitViewLayoutProps {
   onSendMessage: (message: string) => void;
   isLoading: boolean;
   currentProcessStep?: ProcessStep;
+  chainOfThoughtSteps?: ProcessStep[];
   
   // Chart board props
   chartBoardItems: ChartBoardItem[];
@@ -34,6 +35,7 @@ export default function SplitViewLayout({
   onSendMessage,
   isLoading,
   currentProcessStep,
+  chainOfThoughtSteps,
   chartBoardItems,
   onUpdateChartBoardItems,
   onAddToBoard,
@@ -108,8 +110,10 @@ export default function SplitViewLayout({
                   onSendMessage={onSendMessage}
                   isLoading={isLoading}
                   currentProcessStep={currentProcessStep}
+                  chainOfThoughtSteps={chainOfThoughtSteps}
                   onAddToBoard={onAddToBoard}
                   showAddToBoardButtons={true}
+                  isSplitView={effectiveViewMode === 'split'}
                 />
               </div>
             </div>

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -10,6 +10,13 @@ export interface ChatMessage {
         usedFiles?: string[];
         analysisType?: string;
         chartData?: ChartData;
+        // Optional chain-of-thought style reasoning steps for UI display
+        reasoningSteps?: {
+            id: string;
+            text: string;
+            status: 'pending' | 'in_progress' | 'completed';
+            timestamp?: string | Date;
+        }[];
     };
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import SplitViewLayout from './components/layout/SplitViewLayout';
 import { ChatMessage } from './lib/types';
 import { ProcessStep, createProcessStep } from './components/chat/ProcessSteps';
@@ -12,6 +12,8 @@ export default function Home() {
   const [currentProcessStep, setCurrentProcessStep] = useState<ProcessStep | undefined>();
   const [chartBoardItems, setChartBoardItems] = useState<ChartBoardItem[]>([]);
   const [viewMode, setViewMode] = useState<'chat' | 'split' | 'board'>('chat');
+  const [reasoningSteps, setReasoningSteps] = useState<ProcessStep[]>([]);
+  const reasoningStepsRef = useRef<ProcessStep[]>([]);
 
   const handleSendMessage = async (message: string) => {
     const userMessage: ChatMessage = {
@@ -60,19 +62,45 @@ export default function Home() {
               if (data.type === 'step_update') {
                 const step = createProcessStep(data.stepId, data.message, data.status);
                 setCurrentProcessStep(step);
+                // accumulate steps for later display under assistant response
+                setReasoningSteps(prev => {
+                  const idx = prev.findIndex(s => s.id === step.id);
+                  let next: ProcessStep[];
+                  if (idx !== -1) {
+                    const copy = [...prev];
+                    copy[idx] = { ...step };
+                    next = copy;
+                  } else {
+                    next = [...prev, { ...step }];
+                  }
+                  reasoningStepsRef.current = next;
+                  return next;
+                });
               } else if (data.type === 'final_result') {
                 // Create message with NO TEXT CONTENT - only chart
+                // Finalize all reasoning steps as completed for the summary under the message
+                const finalizedSteps = (reasoningStepsRef.current || []).map(s => ({
+                  id: s.id,
+                  text: s.text,
+                  status: 'completed' as const,
+                  timestamp: s.timestamp || new Date()
+                }));
+
                 const assistantMessage: ChatMessage = {
                   id: (Date.now() + 1).toString(),
                   content: '', // Empty content - user only sees chart
                   type: 'assistant',
                   timestamp: new Date(),
                   metadata: {
-                    chartData: data.data.chartData // Only include chart data
+                    chartData: data.data.chartData, // Only include chart data
+                    reasoningSteps: finalizedSteps
                   }
                 };
 
                 setMessages(prev => [...prev, assistantMessage]);
+                // Clear accumulated steps for next run
+                setReasoningSteps([]);
+                reasoningStepsRef.current = [];
               } else if (data.type === 'error') {
                 throw new Error(data.message);
               }
@@ -154,6 +182,7 @@ export default function Home() {
       onSendMessage={handleSendMessage}
       isLoading={isLoading}
       currentProcessStep={currentProcessStep}
+      chainOfThoughtSteps={reasoningSteps}
       chartBoardItems={chartBoardItems}
       onUpdateChartBoardItems={handleUpdateChartBoardItems}
       onAddToBoard={handleAddToBoard}

--- a/components/ai-elements/chain-of-thought/index.tsx
+++ b/components/ai-elements/chain-of-thought/index.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, CheckCircle2, Loader2, Dot, Brain } from 'lucide-react';
+
+type Status = 'complete' | 'active' | 'pending';
+
+interface ChainContextValue {
+  open: boolean;
+  setOpen: (v: boolean) => void;
+}
+
+const ChainContext = createContext<ChainContextValue | null>(null);
+
+function useChainContext() {
+  const ctx = useContext(ChainContext);
+  if (!ctx) throw new Error('ChainOfThought components must be used within <ChainOfThought />');
+  return ctx;
+}
+
+type RootProps = React.ComponentProps<'div'> & {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export function ChainOfThought({ open, defaultOpen = false, onOpenChange, className = '', children, ...rest }: RootProps) {
+  const isControlled = typeof open === 'boolean';
+  const [internalOpen, setInternalOpen] = useState<boolean>(defaultOpen);
+
+  const actualOpen = isControlled ? (open as boolean) : internalOpen;
+  const setOpen = useCallback(
+    (v: boolean) => {
+      if (!isControlled) setInternalOpen(v);
+      onOpenChange?.(v);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const ctx = useMemo(() => ({ open: actualOpen, setOpen }), [actualOpen, setOpen]);
+
+  return (
+    <ChainContext.Provider value={ctx}>
+      <div
+        className={`w-full max-w-2xl rounded-xl border border-input/50 bg-input/20 backdrop-blur-sm ${className}`}
+        {...rest}
+      >
+        {children}
+      </div>
+    </ChainContext.Provider>
+  );
+}
+
+type HeaderProps = React.ComponentProps<'button'> & {
+  children?: React.ReactNode;
+};
+
+export function ChainOfThoughtHeader({ children, className = '', ...rest }: HeaderProps) {
+  const { open, setOpen } = useChainContext();
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(!open)}
+      className={`group w-full flex items-center justify-between px-3 py-2 text-sm text-gray-300 hover:bg-input/30 rounded-t-xl ${className}`}
+      {...rest}
+    >
+      <div className="flex items-center gap-2">
+        {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        <span className="font-medium">{children ?? 'Chain of Thought'}</span>
+      </div>
+      <Brain size={16} className="text-gray-400 transition-colors group-hover:text-white" aria-hidden="true" />
+    </button>
+  );
+}
+
+type ContentProps = React.ComponentProps<'div'>;
+
+export function ChainOfThoughtContent({ children, className = '', ...rest }: ContentProps) {
+  const { open } = useChainContext();
+  return (
+    <div
+      className={`px-3 py-2 transition-all duration-300 ${open ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-1 hidden'} ${className}`}
+      {...rest}
+    >
+      {open ? children : null}
+    </div>
+  );
+}
+
+type LucideIcon = React.ComponentType<{ size?: number; className?: string }>;
+
+type StepProps = React.ComponentProps<'div'> & {
+  icon?: LucideIcon;
+  label: string;
+  description?: string;
+  status?: Status;
+  showConnector?: boolean;
+};
+
+export function ChainOfThoughtStep({ icon: Icon = Dot, label, description, status = 'complete', showConnector = false, className = '', children, ...rest }: StepProps) {
+  const StatusIcon = status === 'complete' ? CheckCircle2 : status === 'active' ? Loader2 : Icon;
+  const spin = status === 'active';
+  return (
+    <div className={`flex items-start gap-3 ${className}`} {...rest}>
+      <div className="relative mt-0.5">
+        <StatusIcon size={16} className={`${spin ? 'animate-spin' : ''} ${status === 'complete' ? 'text-green-400' : 'text-blue-400'}`} />
+        {showConnector && (
+          <div className="-mx-px absolute top-7 bottom-0 left-1/2 w-px bg-border" />
+        )}
+      </div>
+      <div className="flex-1">
+        <p className={`text-sm ${status === 'complete' ? 'text-green-300' : 'text-gray-300'}`}>{label}</p>
+        {description && <p className="text-xs text-gray-400 mt-0.5">{description}</p>}
+        {children && <div className="mt-2">{children}</div>}
+      </div>
+    </div>
+  );
+}
+
+type SearchResultsProps = React.ComponentProps<'div'>;
+
+export function ChainOfThoughtSearchResults({ children, className = '', ...rest }: SearchResultsProps) {
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`} {...rest}>
+      {children}
+    </div>
+  );
+}
+
+type SearchResultProps = React.ComponentProps<'span'>;
+
+export function ChainOfThoughtSearchResult({ children, className = '', ...rest }: SearchResultProps) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border border-input bg-background/40 px-2 py-0.5 text-xs text-gray-300 ${className}`}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
+}
+
+type ImageProps = React.ComponentProps<'div'> & {
+  caption?: string;
+};
+
+export function ChainOfThoughtImage({ caption, children, className = '', ...rest }: ImageProps) {
+  return (
+    <div className={`rounded-lg overflow-hidden border border-input/50 bg-background/30 ${className}`} {...rest}>
+      <div className="w-full">{children}</div>
+      {caption && <div className="px-2 py-1 text-xs text-gray-400 border-t border-input/40">{caption}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
feat(chat): Chain of Thought live + final, UI parity, and fixes

Summary
- Adds a composable Chain of Thought component suite and integrates it:
  - Live Chain of Thought renders during generation (SSE step updates).
  - Final Chain of Thought persists under the assistant reply, above the chart, expanded by default.
  - UI aligned with the AI SDK example: chevron header, right brain icon (hover gray → white), vertical step connectors, status icons.

Why
- Make agent reasoning visible while thinking and after result.
- Avoid confusion caused by previous bottom anchoring and disappearing CoT.
- Fix stale state bug that dropped steps at finalization.

Notable Changes
- New suite: components/ai-elements/chain-of-thought/index.tsx
  - ChainOfThought, ChainOfThoughtHeader, ChainOfThoughtContent, ChainOfThoughtStep, ChainOfThoughtSearchResults, ChainOfThoughtSearchResult, ChainOfThoughtImage
  - ChainOfThoughtStep supports showConnector to draw vertical line between steps.
  - Header shows Brain icon; hover transitions from gray to white.
- Integration:
  - app/components/chat/ChatInterface.tsx: show live steps while generating; connectors enabled.
  - app/components/chat/MessageBubble.tsx: render Chain of Thought above the chart (defaultOpen), with connectors.
- Finalization + stale state fix:
  - app/page.tsx: use reasoningStepsRef to avoid stale state at final_result.
  - Mark all steps as completed in the final assistant message to avoid spinners persisting.

Files Touched
- components/ai-elements/chain-of-thought/index.tsx (new)
- app/components/chat/MessageBubble.tsx
- app/components/chat/ChatInterface.tsx
- app/components/layout/SplitViewLayout.tsx
- app/page.tsx
- app/lib/types.ts

How to Test
- Start a session; ask a question that produces a chart.
- Observe Chain of Thought:
  - During generation: visible in chat area, status updates live.
  - After final: appears above the chart in the assistant bubble, expanded, all steps marked completed.
- Verify header brain icon and chevron; hover transitions on brain icon.
- Confirm connectors between steps (all but last).
- Split view: input anchored bottom in split; empty home screen remains centered.
- No charts → CoT hidden; first chart triggers split view.

Notes
- Some unrelated TS errors exist elsewhere in repo; not part of this change.
- Styling mirrors the guide without adding Radix dependency; can switch to Radix primitives later if desired.
